### PR TITLE
docs: update README to include --recurse-submodules for proper cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple music player built with Python and Rust.
 
 1. Clone the repo:
    ```bash
-   git clone https://github.com/j03-dev/osas-player.git
+   git clone --recurse-submodules https://github.com/j03-dev/osas-player.git
    cd osas-player
    ```
 


### PR DESCRIPTION
I updated the README to include the --recurse-submodules flag in the Git clone command. The original README did not mention this, which caused submodule to be missing when cloning the repository. This pr ensures that users correctly clone the repository with the osas submodule included.